### PR TITLE
CJS: Fix shouldFetch false

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,10 @@
     "rollup": "^3.28.1",
     "rollup-plugin-esbuild": "^5.0.0",
     "serve": "^14.2.1"
+  },
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
   }
 }

--- a/packages/systemjs-cjs-extra/README.md
+++ b/packages/systemjs-cjs-extra/README.md
@@ -1,6 +1,8 @@
 # SystemJS CJS Extra
 
-This is mostly useful if attempting to migrate from SystemJS 0.2x.x to 6.x.x and you do not have control over the built modules that are imported in a project at runtime by SystemJS.
+This package adds the ability to load CJS code in the browser via SystemJS.
+
+This is mostly useful if you want to migrate from SystemJS 0.2x.x to 6.x.x and you do not have control over the built modules that are imported in a project at runtime by SystemJS.
 
 ## Installation
 

--- a/packages/systemjs-cjs-extra/src/index.js
+++ b/packages/systemjs-cjs-extra/src/index.js
@@ -23,6 +23,10 @@ systemJSPrototype.shouldFetch = function (url) {
 systemJSPrototype.instantiate = function (url, parentUrl, meta) {
   const isJavascriptFile = JAVASCRIPT_REGEX.test(url);
 
+  if (!this.shouldFetch(url)) {
+    return originalInstantiate.call(this, url, parentUrl, meta);
+  }
+
   if (isJavascriptFile) {
     return systemJSPrototype
       .fetch(url, {
@@ -39,8 +43,8 @@ systemJSPrototype.instantiate = function (url, parentUrl, meta) {
                 res.statusText +
                 ", loading " +
                 url +
-                (parentUrl ? " from " + parentUrl : "")
-            )
+                (parentUrl ? " from " + parentUrl : ""),
+            ),
           );
         }
         const contentType = res.headers.get("content-type");
@@ -53,8 +57,8 @@ systemJSPrototype.instantiate = function (url, parentUrl, meta) {
                 contentType +
                 '", loading ' +
                 url +
-                (parentUrl ? " from " + parentUrl : "")
-            )
+                (parentUrl ? " from " + parentUrl : ""),
+            ),
           );
         }
 
@@ -67,7 +71,7 @@ systemJSPrototype.instantiate = function (url, parentUrl, meta) {
 
             // Import all dependencies into the SystemJS registry
             const depsPromises = dependencies.map((dep) =>
-              global.System.import(dep, parentUrl ?? url)
+              global.System.import(dep, parentUrl ?? url),
             );
 
             // Make sure all deps are loaded before attempting to exec the module
@@ -99,18 +103,15 @@ systemJSPrototype.instantiate = function (url, parentUrl, meta) {
 
               // Create a System.register format and pass the dependencies
               // and module exports.
-              systemJSPrototype.register(
-                dependencies,
-                function (_export, _context) {
-                  return {
-                    setters: [],
-                    execute: function () {
-                      _export(module.exports);
-                      _export("default", module.exports);
-                    },
-                  };
-                }
-              );
+              systemJSPrototype.register(dependencies, function (_export) {
+                return {
+                  setters: [],
+                  execute: function () {
+                    _export(module.exports);
+                    _export("default", module.exports);
+                  },
+                };
+              });
 
               // Return the new module
               return systemJSPrototype.getRegister(url);


### PR DESCRIPTION
If shouldFetch is false this extra should call the original instantiate rather than continue to fetch and eval.